### PR TITLE
Preserve symlinks when zipping final app

### DIFF
--- a/lib/motion/project/package.rb
+++ b/lib/motion/project/package.rb
@@ -24,7 +24,7 @@ module Motion::Project
         App.fail "Release already exists at ./#{sparkle_release_path}/#{zip_file} (remove it manually with `rake sparkle:clean`)"
       end
       FileUtils.cd(app_release_path) do
-        `zip -r "#{zip_file}" "#{app_file}"`
+        `zip -r --symlinks "#{zip_file}" "#{app_file}"`
       end
       FileUtils.mv "#{app_release_path}/#{zip_file}", "./#{sparkle_release_path}/"
       App.info "Create", "./#{sparkle_release_path}/#{zip_file}"


### PR DESCRIPTION
Without preserving symlinks, final app which include vendored frameworks can become huge. The internal structure of frameworks is full of symlinks, which are replaced by copies of symlinked files when zipping without --symlinks option.
