### PR TITLE
Generate correct urls in appcast.rb

### DIFF
--- a/lib/motion/project/appcast.rb
+++ b/lib/motion/project/appcast.rb
@@ -51,9 +51,9 @@ module Motion::Project
       guid = item.add_element('guid')
       guid.text = "#{@config.name}-#{@config.version}"
       guid.attributes['isPermaLink'] = false
-      item.add_element('sparkle:releaseNotesLink').text = "#{appcast.notes_url}/#{appcast.notes_filename}"
+      item.add_element('sparkle:releaseNotesLink').text = "#{appcast.notes_url}"
       enclosure = item.add_element('enclosure')
-      enclosure.attributes['url'] = "#{appcast.package_url}/#{@package_file}"
+      enclosure.attributes['url'] = "#{appcast.package_url}"
       enclosure.attributes['length'] = "#{@package_size}"
       enclosure.attributes['type'] = "application/octet-stream"
       enclosure.attributes['sparkle:version'] = @config.version


### PR DESCRIPTION
`appcast.notes_url` and `appcast.package_url` generate full paths, so there is no need to append filenames twice.
