### PR TITLE
Create the resources dir if it doesn't exist

### DIFF
--- a/lib/motion/project/sparkle.rb
+++ b/lib/motion/project/sparkle.rb
@@ -88,9 +88,8 @@ module Motion::Project
 
     def generate_keys
       return false unless config_ok?
-      unless File.exist?(sparkle_config_path)
-        FileUtils.mkdir_p sparkle_config_path
-      end
+      create_config_folder
+
       [dsa_param_path, private_key_path, public_key_path].each do |file|
         if File.exist? file
           App.info "Sparkle", "Error: file exists.


### PR DESCRIPTION
And just re-use the helper method for the sparkle config dir
