### PR TITLE
fix handling of version strings

### DIFF
--- a/lib/motion/project/appcast.rb
+++ b/lib/motion/project/appcast.rb
@@ -46,10 +46,10 @@ module Motion::Project
       atom_link.attributes['rel'] = 'self'
       atom_link.attributes['type'] = "application/rss+xml"
       item = channel.add_element 'item'
-      item.add_element('title').text = "#{@config.name} #{@config.version}"
+      item.add_element('title').text = "#{@config.name} #{@config.short_version}"
       item.add_element('pubDate').text = Time.now.strftime("%a, %d %b %Y %H:%M:%S %z")
       guid = item.add_element('guid')
-      guid.text = "#{@config.name}-#{@config.version}"
+      guid.text = "#{@config.name}-#{@config.short_version}"
       guid.attributes['isPermaLink'] = false
       item.add_element('sparkle:releaseNotesLink').text = "#{appcast.notes_url}"
       enclosure = item.add_element('enclosure')
@@ -57,6 +57,7 @@ module Motion::Project
       enclosure.attributes['length'] = "#{@package_size}"
       enclosure.attributes['type'] = "application/octet-stream"
       enclosure.attributes['sparkle:version'] = @config.version
+      enclosure.attributes['sparkle:shortVersionString'] = @config.short_version
       enclosure.attributes['sparkle:dsaSignature'] = @package_signature
       rss
     end

--- a/lib/motion/project/package.rb
+++ b/lib/motion/project/package.rb
@@ -7,8 +7,8 @@ module Motion::Project
       @config.build_mode = :release
       return unless create_zip_file
       App.info "Release", version_string
-      App.info "Version", @config.version
-      App.info "Build", @config.short_version || 'unspecified in Rakefile'
+      App.info "Version", @config.short_version
+      App.info "Build", @config.version || 'unspecified in Rakefile'
       App.info "Size", @package_size.to_s
       sign_package
       create_appcast

--- a/lib/motion/project/sparkle.rb
+++ b/lib/motion/project/sparkle.rb
@@ -44,7 +44,7 @@ module Motion::Project
     end
 
     def version_string
-      "#{@config.version} (#{@config.short_version})"
+      "#{@config.short_version} (#{@config.version})"
     end
 
     def feed_url(url)


### PR DESCRIPTION
the `short_version` contains the app's version number, while the `version` contains the build number.
Fixes #15 